### PR TITLE
Operations content returned in array. Update key value fix.

### DIFF
--- a/crud_config/crud/update.py
+++ b/crud_config/crud/update.py
@@ -28,8 +28,8 @@ def update_keyval(container_path, key, value, tag=None):
     """
     # container = ccget.get_container(container_path)
     key = ccget.get_key(container_path, key, tag)
-    if type(value) is str:
-        v = [value.encode('utf-8')]
+    if type(value) is not list:
+        v = [str(value).encode('utf-8')]
     else:
         v = [x.encode('utf-8') for x in value]
 

--- a/crud_config/routes/gets.py
+++ b/crud_config/routes/gets.py
@@ -314,7 +314,6 @@ def get_content(path):
 
             cache.set("loading-" + cache_key, "True",
                       timeout=app.config['CACHE_LOCKING_SECONDS'])
-            request_recursive = False
             max_recursion = int(app.config['TREE_MAX_RECURSION'])
 
             request_key = None
@@ -356,10 +355,10 @@ def get_content(path):
                     c = ccget.get_container(container)
                     all_values = dict()
                     for key in c.keys:
-                        all_values[key.name] = {'values': list()}
+                        all_values[key.name] = list()
 
                         for value in key.values:
-                            all_values[key.name]['values'].append(value.value)
+                            all_values[key.name].append(value.value)
 
                     return_hash[c.name]= all_values
 
@@ -375,10 +374,10 @@ def get_content(path):
                     c = ccget.get_container(container)
                     all_values = dict()
                     for key in c.keys:
-                        all_values[key.name] = {'values': list()}
+                        all_values[key.name] = list()
 
                         for value in key.values:
-                            all_values[key.name]['values'].append(value.value)
+                            all_values[key.name].append(value.value)
 
                     return_hash[c.name]=all_values
 


### PR DESCRIPTION
Content values are now returned as an array instead of a dictionary with 'values' as the key. I heard a few groans about there being to much to parse in the returned set of data.

Also, I adjusted how key values are updated to function more like the post call. I was getting "integer not iterable" errors when a key's value was a standard int. This change allows for updating keys by passing in a dictionary of 'keyvals' in the same manner as posting them.
